### PR TITLE
feat: 로그인 조회 API 구현

### DIFF
--- a/backend/src/main/java/dev/chrono/chronochallenge/auth/controller/AuthController.java
+++ b/backend/src/main/java/dev/chrono/chronochallenge/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package dev.chrono.chronochallenge.auth.controller;
 
 
 import dev.chrono.chronochallenge.auth.dto.AuthInfo;
+import dev.chrono.chronochallenge.auth.dto.MessageResponse;
 import dev.chrono.chronochallenge.auth.dto.request.LoginRequest;
 import dev.chrono.chronochallenge.auth.service.AuthService;
 import org.springframework.http.HttpStatus;
@@ -39,6 +40,13 @@ public class AuthController {
         AuthInfo authInfo = (AuthInfo) session.getValue("memberId");
         System.out.println(authInfo.getName() + "로그아웃");
         session.invalidate();
+    }
+
+    @GetMapping("/login_check")
+    public ResponseEntity<MessageResponse> loginCheck(HttpSession session) {
+        MessageResponse messageResponse = authService.loginCheck(session);
+
+        return ResponseEntity.status(HttpStatus.OK).body(messageResponse);
     }
 
 }

--- a/backend/src/main/java/dev/chrono/chronochallenge/auth/dto/MessageResponse.java
+++ b/backend/src/main/java/dev/chrono/chronochallenge/auth/dto/MessageResponse.java
@@ -1,0 +1,18 @@
+package dev.chrono.chronochallenge.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MessageResponse {
+
+    private String message;
+
+    private int code;
+
+    @Builder
+    public MessageResponse(String message, int code) {
+        this.message = message;
+        this.code = code;
+    }
+}

--- a/backend/src/main/java/dev/chrono/chronochallenge/auth/service/AuthService.java
+++ b/backend/src/main/java/dev/chrono/chronochallenge/auth/service/AuthService.java
@@ -1,12 +1,14 @@
 package dev.chrono.chronochallenge.auth.service;
 
 import dev.chrono.chronochallenge.auth.dto.AuthInfo;
+import dev.chrono.chronochallenge.auth.dto.MessageResponse;
 import dev.chrono.chronochallenge.auth.dto.request.LoginRequest;
 import dev.chrono.chronochallenge.auth.exception.LoginFailedException;
 import dev.chrono.chronochallenge.member.model.Member;
 import dev.chrono.chronochallenge.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
+import javax.servlet.http.HttpSession;
 import java.util.Optional;
 
 @Service
@@ -25,6 +27,28 @@ public class AuthService {
         String password = loginRequest.getPassword();
         Member member = memberRepository.findByNameAndPassword(name, password).orElseThrow(LoginFailedException::new);
         return new AuthInfo(member.getId(),member.getName());
+    }
+
+    public MessageResponse loginCheck(HttpSession session) {
+
+        MessageResponse messageResponse;
+
+        if(null == session.getAttribute("memberId")) {
+            messageResponse = MessageResponse
+                    .builder()
+                    .message("로그인 상태가 아닙니다.")
+                    .code(0)
+                    .build();
+        } else {
+            AuthInfo authInfo = (AuthInfo) session.getValue("memberId");
+            messageResponse = MessageResponse
+                    .builder()
+                    .message(authInfo.getName() + "님이 로그인한 상태입니다.")
+                    .code(1)
+                    .build();
+        }
+
+        return messageResponse;
     }
 
 }


### PR DESCRIPTION
현재 로그인 되어있는지 확인하는 API를 구현했다.
메세지와 코드를 반환하는 DTO를 만들어서 반환한다.
로그인 상태이면 1, 로그인 상태가 아니면 0 코드를 반환한다.

## 관련 이슈

- Close #32 